### PR TITLE
corrected [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "StochasticRounding"
 uuid = "3843c9a1-1f18-49ff-9d99-1b4c8a8e97ed"
 authors = ["Milan Kloewer"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 
 [compat]
-BFloat16s = "^0.1"
+BFloat16s = "0.1,0.2"
 RandomNumbers = "1.4,1.5"
 julia = "1"
 


### PR DESCRIPTION
For versions 0.x, the caret is interpreted differently: `"^0.1"` covers up to but not including `0.2`. Uncorrected, this forces use of a non-current version of `BFloats16.jl`  and causes other packages to be downgraded (including `CUDA.jl`).
I also bumped your patch version number. After merging this patch, you will need to tell Julia to register the update by adding this as a comment to the latest change  `@JuliaRegistrator register()`.  Clicking on the history message "Merge pull request .." opens the comments.