### PR TITLE
Float64sr via Double64

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,13 @@ version = "0.6.2"
 
 [deps]
 BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
+DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 
 [compat]
 BFloat16s = "0.1, 0.2"
 RandomNumbers = "1.4,1.5"
+DoubleFloats = "1"
 julia = "1"
 
 [extras]

--- a/src/StochasticRounding.jl
+++ b/src/StochasticRounding.jl
@@ -5,11 +5,16 @@ module StochasticRounding
         Float16sr,Float16_stochastic_round,             # Float16 + SR
         Float16_chance_roundup,NaN16sr,Inf16sr,
         Float32sr,Float32_stochastic_round,             # Float32 + SR
-        Float32_chance_roundup,NaN32sr,Inf32sr
+        Float32_chance_roundup,NaN32sr,Inf32sr,
+        Float64sr,Float64_stochastic_round,             # Float64 + SR
+        NaNsr,Infsr
+
 
     # faster random number generator
     import RandomNumbers.Xorshifts.Xoroshiro128Plus
     const Xor128 = Ref{Xoroshiro128Plus}(Xoroshiro128Plus())
+
+    import DoubleFloats: DoubleFloats, Double64
 
     """Reseed the PRNG randomly by recalling."""
     function __init__()
@@ -25,5 +30,6 @@ module StochasticRounding
     include("bfloat16sr.jl")
     include("float16sr.jl")
     include("float32sr.jl")
+    include("float64sr.jl")
 
 end

--- a/src/float64sr.jl
+++ b/src/float64sr.jl
@@ -1,0 +1,129 @@
+"""The Float64 + stochastic rounding type."""
+primitive type Float64sr <: AbstractFloat 64 end
+
+# basic properties
+Base.sign_mask(::Type{Float64sr}) = Base.sign_mask(Float64)
+Base.exponent_mask(::Type{Float64sr}) = Base.exponent_mask(Float64)
+Base.significand_mask(::Type{Float64sr}) = Base.significand_mask(Float64)
+Base.precision(::Type{Float64sr}) = Base.precision(Float64)
+
+Base.one(::Type{Float64sr}) = reinterpret(Float64sr,one(Float64))
+Base.zero(::Type{Float64sr}) = reinterpret(Float64sr,zero(Float64))
+Base.one(::Float64sr) = one(Float64sr)
+Base.zero(::Float64sr) = zero(Float64sr)
+
+Base.typemin(::Type{Float64sr}) = Float64sr(typemin(Float64))
+Base.typemax(::Type{Float64sr}) = Float64sr(typemax(Float64))
+Base.floatmin(::Type{Float64sr}) = Float64sr(floatmin(Float64))
+Base.floatmax(::Type{Float64sr}) = Float64sr(floatmax(Float64))
+
+Base.typemin(::Float64sr) = typemin(Float64sr)
+Base.typemax(::Float64sr) = typemax(Float64sr)
+Base.floatmin(::Float64sr) = floatmin(Float64sr)
+Base.floatmax(::Float64sr) = floatmax(Float64sr)
+
+Base.eps(::Type{Float64sr}) = Float64sr(eps(Float64))
+Base.eps(x::Float64sr) = Float64sr(eps(Float64(x)))
+
+const Infsr = reinterpret(Float64sr, Inf)
+const NaNsr = reinterpret(Float64sr, NaN)
+
+# basic operations
+Base.abs(x::Float64sr) = reinterpret(Float64sr, abs(reinterpret(Float64,x)))
+Base.isnan(x::Float64sr) = isnan(reinterpret(Float64,x))
+Base.isfinite(x::Float64sr) = isfinite(reinterpret(Float64,x))
+
+Base.uinttype(::Type{Float64sr}) = UInt64
+Base.nextfloat(x::Float64sr) = Float64sr(nextfloat(Float64(x)))
+Base.prevfloat(x::Float64sr) = Float64sr(prevfloat(Float64(x)))
+
+Base.:(-)(x::Float64sr) = reinterpret(Float64sr, reinterpret(UInt64, x) ⊻ Base.sign_mask(Float64sr))
+
+# conversions
+Base.Float64(x::Float64sr) = reinterpret(Float64,x)
+Float64sr(x::Float64) = reinterpret(Float64sr,x)
+Float64sr(x::Float16) = Float64sr(Float64(x))
+Float64sr(x::Float32) = Float64sr(Float64(x))
+Base.Float16(x::Float64sr) = Float16(Float64(x))
+Base.Float32(x::Float64sr) = Float32(Float64(x))
+
+DoubleFloats.Double64(x::Float64sr) = Double64(Float64(x))
+
+Float64sr(x::Integer) = Float64sr(Float64(x))
+(::Type{T})(x::Float64sr) where {T<:Integer} = T(Float64(x))
+
+"""Stochastically round x::Double64 to Float64 with distance-proportional probabilities."""
+function Float64_stochastic_round(x::Double64)
+    rbits = rand(Xor128[],UInt64)   # create random bits
+    
+    # create [1,2)-1.5 = [-0.5,0.5)
+    r = reinterpret(Float64,reinterpret(UInt64,one(Float64)) + (rbits >> 12)) - 1.5
+    a = x.hi    # the more significant float64 in x
+    b = x.lo    # the less significant float64 in x
+    u = eps(a)  # = ulp
+
+    return Float64sr(a + (b+u*r))    # (b+u*r) first as a+b would be rounded to a
+end
+
+Base.promote_rule(::Type{Float16}, ::Type{Float64sr}) = Float64sr
+Base.promote_rule(::Type{Float32}, ::Type{Float64sr}) = Float64sr
+Base.promote_rule(::Type{Float64}, ::Type{Float64sr}) = Float64sr
+
+for t in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UInt128)
+    @eval Base.promote_rule(::Type{Float64sr}, ::Type{$t}) = Float64sr
+end
+
+# Rounding
+Base.round(x::Float64sr, r::RoundingMode{:ToZero}) = Float64sr(round(Float64(x), r))
+Base.round(x::Float64sr, r::RoundingMode{:Down}) = Float64sr(round(Float64(x), r))
+Base.round(x::Float64sr, r::RoundingMode{:Up}) = Float64sr(round(Float64(x), r))
+Base.round(x::Float64sr, r::RoundingMode{:Nearest}) = Float64sr(round(Float64(x), r))
+
+# Comparison
+for op in (:(==), :<, :<=, :isless)
+    @eval Base.$op(a::Float64sr, b::Float64sr) = ($op)(Float64(a), Float64(b))
+end
+
+# Arithmetic
+for f in (:+, :-, :*, :/, :^)
+    @eval Base.$f(x::Float64sr, y::Float64sr) = Float64_stochastic_round($(f)(Double64(x), Double64(y)))
+end
+
+for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
+             :atanh,:exp,:exp2,:exp10,:expm1,:log,:log2,:log10,:sqrt,:cbrt,:log1p)
+    @eval begin
+        Base.$func(a::Float64sr) = Float64_stochastic_round($func(Float64(a)))
+    end
+end
+
+for func in (:atan,:hypot)
+    @eval begin
+        Base.$func(a::Float64sr,b::Float64sr) = Float64_stochastic_round($func(Double64(a),Double64(b)))
+    end
+end
+
+
+# Showing
+function Base.show(io::IO, x::Float64sr)
+    if isinf(x)
+        print(io, x < 0 ? "-Infsr" : "Infsr")
+    elseif isnan(x)
+        print(io, "NaNsr")
+    else
+        io2 = IOBuffer()
+        print(io2,Float64(x))
+        f = String(take!(io2))
+        print(io,"Float64sr("*f*")")
+    end
+end
+
+Base.bitstring(x::Float64sr) = bitstring(reinterpret(UInt64,x))
+
+function Base.bitstring(x::Float64sr,mode::Symbol)
+    if mode == :split	# split into sign, exponent, signficand
+        s = bitstring(x)
+        return "$(s[1]) $(s[2:12]) $(s[13:end])"
+    else
+        return bitstring(x)
+    end
+end


### PR DESCRIPTION
fixes #59 

```julia
julia> using StochasticRounding

julia> A = Float64sr.(rand(4,4))
4×4 Matrix{Float64sr}:
 Float64sr(0.38418416963682733)  …  Float64sr(0.5286745680704084)
 Float64sr(0.6002555882832199)      Float64sr(0.5193716738812405)
 Float64sr(0.7037500894099693)      Float64sr(0.4781770819341078)
 Float64sr(0.8019156074397128)      Float64sr(0.522393411487242)

julia> b = Float64sr.(rand(4))
4-element Vector{Float64sr}:
 Float64sr(0.7554796403393423)
 Float64sr(0.4199864825038644)
 Float64sr(0.30487539136735975)
 Float64sr(0.7228777754787546)

julia> A\b
4-element Vector{Float64sr}:
 Float64sr(-0.5018580578417031)
 Float64sr(-1.1517596349045047)
 Float64sr(0.21765870439733434)
 Float64sr(2.8794910547991557)

julia> A\b   # do it again, slightly different answer
4-element Vector{Float64sr}:
 Float64sr(-0.5018580578417027)
 Float64sr(-1.1517596349045056)
 Float64sr(0.21765870439733445)
 Float64sr(2.879491054799156)
```

@avleenk2312 could you try out this branch (and maybe even write some tests for it? 😄) before I merge it?