### PR TITLE
Added missing function definitions resolves #64

### DIFF
--- a/src/bfloat16sr.jl
+++ b/src/bfloat16sr.jl
@@ -21,6 +21,7 @@ Base.typemax(::Type{BFloat16sr}) = InfB16sr
 Base.floatmin(::Type{BFloat16sr}) = reinterpret(BFloat16sr,0x0080)
 Base.floatmax(::Type{BFloat16sr}) = reinterpret(BFloat16sr,0x7f7f)
 minpos(::Type{BFloat16sr}) = reinterpret(BFloat16sr,0x0001)
+Base.maxintfloat(::Type{BFloat16sr}) = BFloat16sr(maxintfloat(BFloat16))
 
 Base.typemin(::BFloat16sr) = typemin(BFloat16sr)
 Base.typemax(::BFloat16sr) = typemax(BFloat16sr)
@@ -48,6 +49,7 @@ BFloat16sr(x::Integer) = BFloat16sr(Float32(x))
 
 Base.Float64(x::BFloat16sr) = Float64(Float32(x))
 Base.Float16(x::BFloat16sr) = Float16(Float32(x))
+BFloat16sr(x::Irrational) = reinterpret(BFloat16sr,BFloat16(x))
 
 # conversion between BFloat16 and BFloat16sr
 BFloat16(x::BFloat16sr) = reinterpret(BFloat16,x)
@@ -83,7 +85,7 @@ function BFloat16_chance_roundup(x::Float32)
 end
 
 # Basic arithmetic
-for f in (:+, :-, :*, :/, :^)
+for f in (:+, :-, :*, :/, :^, :mod)
     @eval Base.$f(x::BFloat16sr, y::BFloat16sr) = BFloat16_stochastic_round($(f)(Float32(x), Float32(y)))
 end
 
@@ -98,6 +100,11 @@ for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
     @eval begin
         Base.$func(a::BFloat16sr) = BFloat16_stochastic_round($func(Float32(a)))
     end
+end
+
+function Base.sincos(x::BFloat16sr)
+    s,c = sincos(Float32(x))
+    return (BFloat16_stochastic_round(s),BFloat16_stochastic_round(c))
 end
 
 for func in (:atan,:hypot)

--- a/src/float16sr.jl
+++ b/src/float16sr.jl
@@ -17,6 +17,7 @@ Base.typemin(::Type{Float16sr}) = Float16sr(typemin(Float16))
 Base.typemax(::Type{Float16sr}) = Float16sr(typemax(Float16))
 Base.floatmin(::Type{Float16sr}) = Float16sr(floatmin(Float16))
 Base.floatmax(::Type{Float16sr}) = Float16sr(floatmax(Float16))
+Base.maxintfloat(::Type{Float16sr}) = Float16sr(maxintfloat(Float16))
 
 Base.typemin(::Float16sr) = typemin(Float16sr)
 Base.typemax(::Float16sr) = typemax(Float16sr)
@@ -104,11 +105,11 @@ for op in (:(==), :<, :<=, :isless)
 end
 
 # Arithmetic
-for f in (:+, :-, :*, :/, :^)
+for f in (:+, :-, :*, :/, :^, :mod)
     @eval Base.$f(x::Float16sr, y::Float16sr) = Float16_stochastic_round($(f)(Float32(x), Float32(y)))
 end
 
-for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
+for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,:sincos,
              :atanh,:exp,:exp2,:exp10,:expm1,:log,:log2,:log10,:sqrt,:cbrt,:log1p)
     @eval begin
         Base.$func(a::Float16sr) = Float16_stochastic_round($func(Float32(a)))

--- a/src/float16sr.jl
+++ b/src/float16sr.jl
@@ -49,6 +49,9 @@ Float16sr(x::Float64) = Float16sr(Float32(x))
 Base.Float32(x::Float16sr) = Float32(Float16(x))
 Base.Float64(x::Float16sr) = Float64(Float16(x))
 
+#irrationals
+Float16sr(x::Irrational) = reinterpret(Float16sr,Float16(x))
+
 # converting to and from BFloat16
 Float16sr(x::BFloat16) = Float16sr(Float32(x))
 BFloat16(x::Float16sr) = BFloat16(Float16(x))
@@ -109,7 +112,7 @@ for f in (:+, :-, :*, :/, :^, :mod)
     @eval Base.$f(x::Float16sr, y::Float16sr) = Float16_stochastic_round($(f)(Float32(x), Float32(y)))
 end
 
-for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,:sincos,
+for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
              :atanh,:exp,:exp2,:exp10,:expm1,:log,:log2,:log10,:sqrt,:cbrt,:log1p)
     @eval begin
         Base.$func(a::Float16sr) = Float16_stochastic_round($func(Float32(a)))
@@ -120,6 +123,12 @@ for func in (:atan,:hypot)
     @eval begin
         Base.$func(a::Float16sr,b::Float16sr) = Float16_stochastic_round($func(Float32(a),Float32(b)))
     end
+end
+
+#sincos function
+function Base.sincos(x::Float16sr)
+    s,c = sincos(Float32(x))
+    return (Float16_stochastic_round(s),Float16_stochastic_round(c))
 end
 
 function Base.show(io::IO, x::Float16sr)

--- a/src/float32sr.jl
+++ b/src/float32sr.jl
@@ -22,13 +22,10 @@ Base.floatmin(::Type{Float32sr}) = Float32sr(floatmin(Float32))
 Base.floatmax(::Type{Float32sr}) = Float32sr(floatmax(Float32))
 Base.maxintfloat(::Type{Float32sr}) = Float32sr(maxintfloat(Float32))
 
-
 Base.typemin(::Float32sr) = typemin(Float32sr)
 Base.typemax(::Float32sr) = typemax(Float32sr)
 Base.floatmin(::Float32sr) = floatmin(Float32sr)
 Base.floatmax(::Float32sr) = floatmax(Float32sr)
-
-
 
 Base.eps(::Type{Float32sr}) = Float32sr(eps(Float32))
 Base.eps(x::Float32sr) = Float32sr(eps(Float32(x)))
@@ -127,7 +124,7 @@ for func in (:atan,:hypot)
         Base.$func(a::Float32sr,b::Float32sr) = Float32_stochastic_round($func(Float64(a),Float64(b)))
     end
 end
-#sincos function
+
 function Base.sincos(x::Float32sr)
     s,c = sincos(Float64(x))
     return (Float32_stochastic_round(s),Float32_stochastic_round(c))

--- a/src/float32sr.jl
+++ b/src/float32sr.jl
@@ -20,11 +20,14 @@ Base.typemin(::Type{Float32sr}) = Float32sr(typemin(Float32))
 Base.typemax(::Type{Float32sr}) = Float32sr(typemax(Float32))
 Base.floatmin(::Type{Float32sr}) = Float32sr(floatmin(Float32))
 Base.floatmax(::Type{Float32sr}) = Float32sr(floatmax(Float32))
+Base.maxintfloat(::Type{Float32sr}) = Float32sr(maxintfloat(Float32))
+
 
 Base.typemin(::Float32sr) = typemin(Float32sr)
 Base.typemax(::Float32sr) = typemax(Float32sr)
 Base.floatmin(::Float32sr) = floatmin(Float32sr)
 Base.floatmax(::Float32sr) = floatmax(Float32sr)
+
 
 Base.eps(::Type{Float32sr}) = Float32sr(eps(Float32))
 Base.eps(x::Float32sr) = Float32sr(eps(Float32(x)))

--- a/src/float32sr.jl
+++ b/src/float32sr.jl
@@ -108,7 +108,7 @@ for op in (:(==), :<, :<=, :isless)
 end
 
 # Arithmetic
-for f in (:+, :-, :*, :/, :^)
+for f in (:+, :-, :*, :/, :^, :mod)
     @eval Base.$f(x::Float32sr, y::Float32sr) = Float32_stochastic_round($(f)(Float64(x), Float64(y)))
 end
 

--- a/src/float32sr.jl
+++ b/src/float32sr.jl
@@ -29,6 +29,7 @@ Base.floatmin(::Float32sr) = floatmin(Float32sr)
 Base.floatmax(::Float32sr) = floatmax(Float32sr)
 
 
+
 Base.eps(::Type{Float32sr}) = Float32sr(eps(Float32))
 Base.eps(x::Float32sr) = Float32sr(eps(Float32(x)))
 
@@ -53,6 +54,8 @@ Float32sr(x::Float16) = Float32sr(Float32(x))
 Float32sr(x::Float64) = Float32sr(Float32(x))
 Base.Float16(x::Float32sr) = Float16(Float32(x))
 Base.Float64(x::Float32sr) = Float64(Float32(x))
+#irrationals
+Float32sr(x::Irrational) = reinterpret(Float32sr,Float32(x))
 
 Float32sr(x::Integer) = Float32sr(Float32(x))
 (::Type{T})(x::Float32sr) where {T<:Integer} = T(Float32(x))
@@ -112,7 +115,7 @@ for f in (:+, :-, :*, :/, :^, :mod)
     @eval Base.$f(x::Float32sr, y::Float32sr) = Float32_stochastic_round($(f)(Float64(x), Float64(y)))
 end
 
-for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,:sincos,
+for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
              :atanh,:exp,:exp2,:exp10,:expm1,:log,:log2,:log10,:sqrt,:cbrt,:log1p)
     @eval begin
         Base.$func(a::Float32sr) = Float32_stochastic_round($func(Float64(a)))
@@ -124,7 +127,11 @@ for func in (:atan,:hypot)
         Base.$func(a::Float32sr,b::Float32sr) = Float32_stochastic_round($func(Float64(a),Float64(b)))
     end
 end
-
+#sincos function
+function Base.sincos(x::Float32sr)
+    s,c = sincos(Float64(x))
+    return (Float32_stochastic_round(s),Float32_stochastic_round(c))
+end
 
 # Showing
 function Base.show(io::IO, x::Float32sr)

--- a/src/float32sr.jl
+++ b/src/float32sr.jl
@@ -112,7 +112,7 @@ for f in (:+, :-, :*, :/, :^)
     @eval Base.$f(x::Float32sr, y::Float32sr) = Float32_stochastic_round($(f)(Float64(x), Float64(y)))
 end
 
-for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,
+for func in (:sin,:cos,:tan,:asin,:acos,:atan,:sinh,:cosh,:tanh,:asinh,:acosh,:sincos,
              :atanh,:exp,:exp2,:exp10,:expm1,:log,:log2,:log10,:sqrt,:cbrt,:log1p)
     @eval begin
         Base.$func(a::Float32sr) = Float32_stochastic_round($func(Float64(a)))


### PR DESCRIPTION
As resolved by you the following function definitions have been added to Float16sr and Float32sr for compatibility with GenericFFT:

1. Base.maxintfloat
2. Irrational
3. sincos

I have tested the code. It works well with GenericFFT.

Also, I use mod function in PIC so I have added the definition for it under basic operations as well for both Float16sr and Float32sr.
