### PR TITLE
show without Float??sr(...)

### DIFF
--- a/src/bfloat16sr.jl
+++ b/src/bfloat16sr.jl
@@ -122,20 +122,7 @@ for t in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UInt
     @eval Base.promote_rule(::Type{BFloat16sr}, ::Type{$t}) = BFloat16sr
 end
 
-# Showing
-function Base.show(io::IO, x::BFloat16sr)
-    if isinf(x)
-        print(io, x < 0 ? "-InfB16" : "InfB16")
-    elseif isnan(x)
-        print(io, "NaNB16")
-    else
-        io2 = IOBuffer()
-        print(io2,Float32(x))
-        f = String(take!(io2))
-        print(io,"BFloat16sr("*f*")")
-    end
-end
-
+Base.show(io::IO, x::BFloat16sr) = show(io,BFloat16(x))
 Base.bitstring(x::BFloat16sr) = bitstring(reinterpret(UInt16,x))
 
 function Base.bitstring(x::BFloat16sr,mode::Symbol)

--- a/src/float16sr.jl
+++ b/src/float16sr.jl
@@ -121,19 +121,7 @@ for func in (:atan,:hypot)
     end
 end
 
-function Base.show(io::IO, x::Float16sr)
-    if isinf(x)
-        print(io, x < 0 ? "-Inf16" : "Inf16")
-    elseif isnan(x)
-        print(io, "NaN16")
-    else
-        io2 = IOBuffer()
-        print(io2,Float32(x))
-        f = String(take!(io2))
-        print(io,"Float16sr("*f*")")
-    end
-end
-
+Base.show(io::IO, x::Float16sr) = show(io,Float16(x))
 Base.bitstring(x::Float16sr) = bitstring(reinterpret(UInt16,x))
 
 function Base.bitstring(x::Float16sr,mode::Symbol)

--- a/src/float32sr.jl
+++ b/src/float32sr.jl
@@ -122,21 +122,7 @@ for func in (:atan,:hypot)
     end
 end
 
-
-# Showing
-function Base.show(io::IO, x::Float32sr)
-    if isinf(x)
-        print(io, x < 0 ? "-Inf32sr" : "Inf32sr")
-    elseif isnan(x)
-        print(io, "NaN32sr")
-    else
-        io2 = IOBuffer()
-        print(io2,Float32(x))
-        f = String(take!(io2))
-        print(io,"Float32sr("*f*")")
-    end
-end
-
+Base.show(io::IO, x::Float32sr) = show(io,Float32(x))
 Base.bitstring(x::Float32sr) = bitstring(reinterpret(UInt32,x))
 
 function Base.bitstring(x::Float32sr,mode::Symbol)


### PR DESCRIPTION
was
```julia
julia> a = Complex{Float32sr}.(rand(ComplexF32,4))
4-element Vector{Complex{Float32sr}}:
  Float32sr(0.5325291) + Float32sr(0.18148404)im
 Float32sr(0.96100646) + Float32sr(0.38610566)im
  Float32sr(0.3841135) + Float32sr(0.59408957)im
  Float32sr(0.8953621) + Float32sr(0.61041445)im
```
now
```julia
julia> fft(a)
4-element Vector{Complex{Float32sr}}:
  0.5139984f0 + 1.1588799f0im
  1.1781136f0 - 0.38807225f0im
 -0.6409829f0 + 1.4666964f0im
  -1.051129f0 - 2.237504f0im
```
so the stochastic rounding is only visible in the type. Otherwise the terminal output is just too easily flooded with `Float32sr` prints