### PR TITLE
round :Down removed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StochasticRounding"
 uuid = "3843c9a1-1f18-49ff-9d99-1b4c8a8e97ed"
 authors = ["Milan Kloewer and StochasticRounding.jl contributors"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"

--- a/src/bfloat16.jl
+++ b/src/bfloat16.jl
@@ -55,4 +55,3 @@ Base.BigFloat(x::BFloat16) = BigFloat(Float32(x))
 Base.maxintfloat(::Type{BFloat16}) = reinterpret(BFloat16,0x4380)
 
 Base.round(x::BFloat16, r::RoundingMode{:ToZero}) = BFloat16(trunc(Float32(x)))
-Base.round(x::BFloat16, r::RoundingMode{:Down}) = BFloat16(floor(Float32(x)))


### PR DESCRIPTION
Removes the precompilation warnings
```julia
  ? StochasticRounding
  65 dependencies successfully precompiled in 515 seconds. 450 already precompiled.
  1 dependency failed but may be precompilable after restarting julia
  1 dependency had output during precompilation:
┌ StochasticRounding
│  WARNING: Method definition round(BFloat16s.BFloat16, Base.Rounding.RoundingMode{:Down}) in module BFloat16s at /Users/milan/.julia/packages/BFloat16s/uUmkF/src/bfloat16.jl:66 overwritten in module StochasticRounding at /Users/milan/.julia/packages/StochasticRounding/MuErm/src/bfloat16.jl:58.
│  ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.
└

```