### PR TITLE
Add an extension for Enzyme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,16 @@ DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 
+[weakdeps]
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+
+[extensions]
+EnzymeExt = "Enzyme"
+
 [compat]
 BFloat16s = "0.1, 0.2, 0.3, 0.4, 0.5"
 DoubleFloats = "1"
+Enzyme = "0.13"
 Random = "1"
 RandomNumbers = "^1.4"
 julia = "1"
@@ -19,6 +26,7 @@ julia = "1"
 [extras]
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 
 [targets]
 test = ["Test", "DifferentialEquations"]

--- a/ext/EnzymeExt.jl
+++ b/ext/EnzymeExt.jl
@@ -4,12 +4,28 @@ using Enzyme
 using StochasticRounding
 import StochasticRounding: stochastic_round
 
+function Enzyme.typetree_inner(::Type{Float64sr}, ctx, dl, seen::Enzyme.Compiler.TypeTreeTable)
+    return Enzyme.TypeTree(Enzyme.API.DT_Double, -1, ctx)
+end
+
+function Enzyme.get_offsets(::Type{Float64sr})
+    return ((Enzyme.API.DT_Double, 0),)
+en
+
 function Enzyme.typetree_inner(::Type{Float32sr}, ctx, dl, seen::Enzyme.Compiler.TypeTreeTable)
     return Enzyme.TypeTree(Enzyme.API.DT_Float, -1, ctx)
 end
 
 function Enzyme.get_offsets(::Type{Float32sr})
     return ((Enzyme.API.DT_Float, 0),)
+end
+
+function Enzyme.typetree_inner(::Type{Float16sr}, ctx, dl, seen::Enzyme.Compiler.TypeTreeTable)
+    return Enzyme.TypeTree(Enzyme.API.DT_Half, -1, ctx)
+end
+
+function Enzyme.get_offsets(::Type{Float16sr})
+    return ((Enzyme.API.DT_Half, 0),)
 end
 
 import Enzyme: EnzymeRules

--- a/ext/EnzymeExt.jl
+++ b/ext/EnzymeExt.jl
@@ -1,0 +1,25 @@
+module EnzymeExt
+
+using Enzyme
+using StochasticRounding
+import StochasticRounding: stochastic_round
+
+function Enzyme.typetree_inner(::Type{Float32sr}, ctx, dl, seen::Enzyme.Compiler.TypeTreeTable)
+    return Enzyme.TypeTree(Enzyme.API.DT_Float, -1, ctx)
+end
+
+import Enzyme: EnzymeRules
+import Enzyme: Const, Duplicated
+
+function EnzymeRules.forward(config, ::Const{typeof(stochastic_round)}, ::Type{<:DuplicatedNoNeed}, ::Const{Type{T}}, x::Duplicated) where T
+    stochastic_round(T, x.dval)
+end
+
+function EnzymeRules.forward(config, ::Const{typeof(stochastic_round)}, ::Type{<:Duplicated}, ::Const{Type{T}}, x::Duplicated) where T
+    Duplicated(
+        stochastic_round(T, x.val),
+        stochastic_round(T, x.dval)
+    )
+end
+
+end # module

--- a/ext/EnzymeExt.jl
+++ b/ext/EnzymeExt.jl
@@ -10,7 +10,7 @@ end
 
 function Enzyme.get_offsets(::Type{Float64sr})
     return ((Enzyme.API.DT_Double, 0),)
-en
+end
 
 function Enzyme.typetree_inner(::Type{Float32sr}, ctx, dl, seen::Enzyme.Compiler.TypeTreeTable)
     return Enzyme.TypeTree(Enzyme.API.DT_Float, -1, ctx)

--- a/ext/EnzymeExt.jl
+++ b/ext/EnzymeExt.jl
@@ -8,6 +8,10 @@ function Enzyme.typetree_inner(::Type{Float32sr}, ctx, dl, seen::Enzyme.Compiler
     return Enzyme.TypeTree(Enzyme.API.DT_Float, -1, ctx)
 end
 
+function Enzyme.get_offsets(::Type{Float32sr})
+    return ((Enzyme.API.DT_Float, 0),)
+end
+
 import Enzyme: EnzymeRules
 import Enzyme: Const, Duplicated
 


### PR DESCRIPTION
Requires https://github.com/EnzymeAD/Enzyme.jl/pull/2551

It's a little bit "weird" in that we tell Enzyme to just treat this as a Float32 and then use a custom rule for `stochastic_round`.

During Reverse mode we are performing accumulation and this strategy would not perform stochastic rounding for those operations.
